### PR TITLE
Check if key is in returned value first

### DIFF
--- a/norduniclient/models.py
+++ b/norduniclient/models.py
@@ -1188,8 +1188,9 @@ class RoleRelationship(BaseRelationshipModel):
 
         ret = core.query_to_dict(self.manager, q)
 
-        bundle = core.get_relationship_bundle(self.manager, ret['relation_id'])
-        self.load(bundle)
+        if 'relation_id' in ret:
+            bundle = core.get_relationship_bundle(self.manager, ret['relation_id'])
+            self.load(bundle)
 
     @classmethod
     def get_relationship_model(cls, manager, relationship_id):


### PR DESCRIPTION
Some new developments has uncovered this error, if the relation_id is not provided is because the relation itself doesn't exists. 