### PR TITLE
Class method to check organization id

### DIFF
--- a/norduniclient/models.py
+++ b/norduniclient/models.py
@@ -965,7 +965,7 @@ class OrganizationModel(RelationModel):
         return self._basic_write_query_to_dict(q, address_handle_id=address_handle_id)
 
     @classmethod
-    def check_existent_organization_id(cls, organization_id, manager):
+    def check_existent_organization_id(cls, organization_id, manager=None):
         if not manager:
             manager = core.GraphDB.get_instance().manager
 

--- a/norduniclient/models.py
+++ b/norduniclient/models.py
@@ -965,15 +965,24 @@ class OrganizationModel(RelationModel):
         return self._basic_write_query_to_dict(q, address_handle_id=address_handle_id)
 
     @classmethod
-    def check_existent_organization_id(cls, organization_id, manager=None):
+    def check_existent_organization_id(cls, organization_id, handle_id=None, manager=None):
         if not manager:
             manager = core.GraphDB.get_instance().manager
+
+        handle_query = ''
+        if handle_id:
+            # string format
+            if isinstance(handle_id, six.string_types):
+                handle_id = "'{}'".format(handle_id)
+            
+            handle_query = 'AND n.handle_id <> {}'.format(handle_id)
 
         q = """
         MATCH (n:Node:Organization)
         WHERE n.organization_id="{organization_id}"
+        {handle_query}
         RETURN count(n) > 0 AS exists
-        """.format(organization_id=organization_id)
+        """.format(organization_id=organization_id, handle_query=handle_query)
 
         res = core.query_to_dict(manager, q)
 

--- a/norduniclient/models.py
+++ b/norduniclient/models.py
@@ -964,6 +964,21 @@ class OrganizationModel(RelationModel):
             """
         return self._basic_write_query_to_dict(q, address_handle_id=address_handle_id)
 
+    @classmethod
+    def check_existent_organization_id(cls, organization_id, manager):
+        if not manager:
+            manager = core.GraphDB.get_instance().manager
+
+        q = """
+        MATCH (n:Node:Organization)
+        WHERE n.organization_id="{organization_id}"
+        RETURN count(n) > 0 AS exists
+        """.format(organization_id=organization_id)
+
+        res = core.query_to_dict(manager, q)
+
+        return res['exists']
+
 
 class ProviderModel(RelationModel):
     pass

--- a/norduniclient/tests/test_models.py
+++ b/norduniclient/tests/test_models.py
@@ -915,8 +915,11 @@ class ModelsTests(Neo4jTestCase):
     def test_check_organization_id(self):
         existent_orgid = 'ORG1'
         nonexistent_orgid = 'ORG3'
-        expected_true = models.OrganizationModel.check_existent_organization_id(existent_orgid, self.neo4jdb)
-        expected_false = models.OrganizationModel.check_existent_organization_id(nonexistent_orgid, self.neo4jdb)
+        expected_true = models.OrganizationModel.check_existent_organization_id(existent_orgid, None, self.neo4jdb)
+        expected_false = models.OrganizationModel.check_existent_organization_id(nonexistent_orgid, None, self.neo4jdb)
 
         self.assertTrue(expected_true)
+        self.assertFalse(expected_false)
+
+        expected_false = models.OrganizationModel.check_existent_organization_id(existent_orgid, '113', self.neo4jdb)
         self.assertFalse(expected_false)

--- a/norduniclient/tests/test_models.py
+++ b/norduniclient/tests/test_models.py
@@ -149,8 +149,8 @@ class ModelsTests(Neo4jTestCase):
 
         q3 = """
             // Create organization and contact nodes
-            CREATE (organization1:Node:Relation:Organization{name:'Organization1', handle_id:'113'}),
-            (organization2:Node:Relation:Organization{name:'Organization2', handle_id:'114'}),
+            CREATE (organization1:Node:Relation:Organization{name:'Organization1', handle_id:'113', organization_id:'ORG1'}),
+            (organization2:Node:Relation:Organization{name:'Organization2', handle_id:'114', organization_id:'ORG2'}),
             (contact1:Node:Relation:Contact{name:'Contact1', handle_id:'115'}),
             (contact2:Node:Relation:Contact{name:'Contact2', handle_id:'116'}),
             (procedure1:Node:Logical:Procedure{name:'Procedure1', handle_id:'119'}),
@@ -911,3 +911,12 @@ class ModelsTests(Neo4jTestCase):
         organization2.add_address('127')
         outgoing_relations = organization2.get_outgoing_relations()
         self.assertIsInstance(outgoing_relations['Has_address'][0]['node'], models.AddressModel)
+
+    def test_check_organization_id(self):
+        existent_orgid = 'ORG1'
+        nonexistent_orgid = 'ORG3'
+        expected_true = models.OrganizationModel.check_existent_organization_id(existent_orgid, self.neo4jdb)
+        expected_false = models.OrganizationModel.check_existent_organization_id(nonexistent_orgid, self.neo4jdb)
+
+        self.assertTrue(expected_true)
+        self.assertFalse(expected_false)


### PR DESCRIPTION
In order to provide a function to be used inside form validation, a class method was added to OrganizationModel in order to check if an organization id is already present in the database.