### PR TITLE
Unique parentorg

### DIFF
--- a/norduniclient/models.py
+++ b/norduniclient/models.py
@@ -917,12 +917,22 @@ class CustomerModel(RelationModel):
     pass
 
 class OrganizationModel(RelationModel):
-    def set_parent(self, org_handle_id):
+    def set_parent(self, org_handle_id, overwrite=False):
         q = """
             MATCH (n:Node:Organization {handle_id: {handle_id}}), (m:Node:Organization {handle_id: {org_handle_id}})
             MERGE (m)-[r:Parent_of]->(n)
             RETURN m as created, r, n as node
             """
+
+        if overwrite:
+            q = """
+                MATCH (n:Node:Organization {handle_id: {handle_id}}), (m:Node:Organization {handle_id: {org_handle_id}})
+                OPTIONAL MATCH (n)<-[s:Parent_of]-(x:Node:Organization)
+                MERGE (m)-[r:Parent_of]->(n)
+                DELETE s
+                RETURN m as created, r, n as node
+                """
+
         return self._basic_write_query_to_dict(q, org_handle_id=org_handle_id)
 
     def set_child(self, org_handle_id):

--- a/norduniclient/tests/test_models.py
+++ b/norduniclient/tests/test_models.py
@@ -963,7 +963,7 @@ class ModelsTests(Neo4jTestCase):
 
     def test_check_organization_id(self):
         existent_orgid = 'ORG1'
-        nonexistent_orgid = 'ORG3'
+        nonexistent_orgid = 'ORG0'
         expected_true = models.OrganizationModel.check_existent_organization_id(existent_orgid, None, self.neo4jdb)
         expected_false = models.OrganizationModel.check_existent_organization_id(nonexistent_orgid, None, self.neo4jdb)
 

--- a/norduniclient/tests/test_models.py
+++ b/norduniclient/tests/test_models.py
@@ -151,6 +151,7 @@ class ModelsTests(Neo4jTestCase):
             // Create organization and contact nodes
             CREATE (organization1:Node:Relation:Organization{name:'Organization1', handle_id:'113', organization_id:'ORG1'}),
             (organization2:Node:Relation:Organization{name:'Organization2', handle_id:'114', organization_id:'ORG2'}),
+            (organization3:Node:Relation:Organization{name:'Organization3', handle_id:'128', organization_id:'ORG3'}),
             (contact1:Node:Relation:Contact{name:'Contact1', handle_id:'115'}),
             (contact2:Node:Relation:Contact{name:'Contact2', handle_id:'116'}),
             (procedure1:Node:Logical:Procedure{name:'Procedure1', handle_id:'119'}),
@@ -607,11 +608,39 @@ class ModelsTests(Neo4jTestCase):
         self.assertEqual(len(relations['Responsible_for']), 1)
 
     def test_set_parent(self):
+        # add several parent orgs
         organization1 = core.get_node_model(self.neo4jdb, handle_id='113')
         organization2 = core.get_node_model(self.neo4jdb, handle_id='114')
+        organization3 = core.get_node_model(self.neo4jdb, handle_id='128')
+
         organization2.set_parent(organization1.handle_id)
+        organization2.set_parent(organization3.handle_id)
+
         relations = organization2.get_relations()
-        self.assertIsInstance(relations['Parent_of'][0]['node'], models.OrganizationModel)
+        parent1_org = relations['Parent_of'][0]['node']
+        parent2_org = relations['Parent_of'][1]['node']
+
+        self.assertIsInstance(parent1_org, models.OrganizationModel)
+        self.assertIsInstance(parent2_org, models.OrganizationModel)
+
+        self.assertEqual(organization1.handle_id, parent1_org.handle_id)
+        self.assertEqual(organization3.handle_id, parent2_org.handle_id)
+
+    def test_set_parent_unique(self):
+        # add several parent orgs
+        organization1 = core.get_node_model(self.neo4jdb, handle_id='113')
+        organization2 = core.get_node_model(self.neo4jdb, handle_id='114')
+        organization3 = core.get_node_model(self.neo4jdb, handle_id='128')
+
+        organization2.set_parent(organization1.handle_id, overwrite=True)
+        organization2.set_parent(organization3.handle_id, overwrite=True)
+
+        relations = organization2.get_relations()
+        parent1_org = relations['Parent_of'][0]['node']
+
+        self.assertIsInstance(parent1_org, models.OrganizationModel)
+        self.assertEqual(organization3.handle_id, parent1_org.handle_id)
+        self.assertEqual(len(relations['Parent_of']), 1)
 
     def test_get_outgoing_relations(self):
         contact1 = core.get_node_model(self.neo4jdb, handle_id='115')
@@ -619,7 +648,7 @@ class ModelsTests(Neo4jTestCase):
         self.assertIsInstance(relations['Works_for'][0]['node'], models.OrganizationModel)
 
         expected_value = self.role_name_1
-        self.assertEquals(relations['Works_for'][0]['relationship']['name'], expected_value)
+        self.assertEqual(relations['Works_for'][0]['relationship']['name'], expected_value)
 
     def test_contact_role_org(self):
         contact1 = core.get_node_model(self.neo4jdb, handle_id='115')

--- a/norduniclient/tests/test_models.py
+++ b/norduniclient/tests/test_models.py
@@ -623,8 +623,8 @@ class ModelsTests(Neo4jTestCase):
         self.assertIsInstance(parent1_org, models.OrganizationModel)
         self.assertIsInstance(parent2_org, models.OrganizationModel)
 
-        self.assertEqual(organization1.handle_id, parent1_org.handle_id)
-        self.assertEqual(organization3.handle_id, parent2_org.handle_id)
+        self.assertEqual(organization3.handle_id, parent1_org.handle_id)
+        self.assertEqual(organization1.handle_id, parent2_org.handle_id)
 
     def test_set_parent_unique(self):
         # add several parent orgs


### PR DESCRIPTION
In SRI we need to reduce the multiplicity of the parent-offpring relationship between Organizations. An Organization may have multiple offspring but it won't have more than one parent. With an overwrite argument we can easily achieve this.